### PR TITLE
Move filtering configuration to struct

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,9 +1,13 @@
+use crate::find::Filter;
 use crate::{duration::parse_duration, size::Size};
 use itertools::Itertools;
 use regex::Regex;
+use std::fs;
 use std::time::Duration;
+use std::time::SystemTime;
 use std::{path::PathBuf, str::FromStr};
 use structopt::StructOpt;
+use walkdir::DirEntry;
 
 #[cfg(not(target_os = "windows"))]
 static APP_NAME: &str = "prn";
@@ -152,6 +156,10 @@ impl Config {
             log::error!("Path does not exist: {:?}", path);
         }
         path.exists()
+    }
+
+    pub fn filters(&self) -> Filter {
+        self.into()
     }
 }
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -181,7 +181,7 @@ impl Default for Config {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Mode {
     File,
     Dir,


### PR DESCRIPTION
Create struct Filter and move the filtering configuration to it. This is meant to isolate the filtering logic for the purpose of;
1. Make it simpler to test the filtering logic in isolation in unit tests
2. Improve the performance a bit since it allows for less repeated calls to metadata on an entity