### PR TITLE
Do not panic on missing file

### DIFF
--- a/src/find.rs
+++ b/src/find.rs
@@ -155,7 +155,11 @@ impl Default for Filter {
 
 pub fn summarize(files: Vec<DirEntry>) -> (u64, u64) {
     let found: u64 = files.len() as u64;
-    let size: u64 = files.iter().map(|f| f.metadata().unwrap().len()).sum();
+    let size: u64 = files
+        .iter()
+        .filter_map(|f| f.metadata().ok())
+        .map(|m| m.len())
+        .sum();
 
     (found, size)
 }


### PR DESCRIPTION
Remove unwrap on call for metadata, which would cause a panic if a file was deleted between the time it was found and the metadata was requested.